### PR TITLE
changefirst [2/7] Make API a bit more generic, mostly in ToxBase

### DIFF
--- a/codemod_tox/base.py
+++ b/codemod_tox/base.py
@@ -1,36 +1,56 @@
 from __future__ import annotations
 
-from typing import Generator
+from typing import Callable, Generator, TypeVar
 
-from .utils import _common_prefix
+from .utils import common_prefix
+
+T = TypeVar("T")
 
 
 class ToxBase:
-    def all(self) -> Generator[str, None, None]:  # pragma: no cover
+    def __iter__(self) -> Generator[str, None, None]:  # pragma: no cover
         raise NotImplementedError
+
+    def map(self, func: Callable[[str], T]) -> Generator[T, None, None]:
+        for x in self:
+            yield func(x)
+
+    def map_all(self, func: Callable[[str], bool]) -> bool:
+        """Wrapper around all(map(...))"""
+        return all(self.map(func))
+
+    def map_any(self, func: Callable[[str], bool]) -> bool:
+        """Wrapper around any(map(...))"""
+        return any(self.map(func))
 
     def startswith(self, prefix: str) -> bool:
         """
         Returns whether all possibilities start with `prefix`.
         """
-        for x in self.all():
-            if not x.startswith(prefix):
-                return False
-        return True
+        return self.map_all(lambda x: x.startswith(prefix))
 
-    def empty(self) -> bool:
-        return not any(self.all())
+    def fold(self, func: Callable[[str, str], str]) -> str:
+        """Like reduce"""
+        prev = None
+        for item in self:
+            if prev is None:
+                prev = item
+            else:
+                prev = func(prev, item)
+        assert prev is not None
+        return prev
 
     def common_prefix(self) -> str:
-        prev = None
-        for env in self.all():
-            if prev is None:
-                prev = env
-            else:
-                prev = _common_prefix(env, prev)
-        assert prev is not None  # 0 options?
-        return prev
+        """Returns the string that is common prefix."""
+        return self.fold(common_prefix)
+
+    def __bool__(self) -> bool:
+        """Returns whether any of the possibilities are truthy"""
+        return self.map_any(lambda x: bool(x))
 
     @classmethod
     def parse(cls, s: str) -> "ToxBase":  # pragma: no cover
+        raise NotImplementedError
+
+    def __str__(self) -> str:  # pragma: no cover
         raise NotImplementedError

--- a/codemod_tox/envlist.py
+++ b/codemod_tox/envlist.py
@@ -6,10 +6,9 @@ from typing import Generator
 from .base import ToxBase
 from .env import ToxEnv
 from .parse import TOX_ENV_TOKEN_RE
-from .utils import _marklast
 
 
-@dataclass
+@dataclass(frozen=True)
 class ToxEnvlist(ToxBase):
     """
     An envlist.
@@ -18,15 +17,15 @@ class ToxEnvlist(ToxBase):
 
     Although both comma and newline separated are supported during parsing,
     only newline separated will be output with `str()`.  Check that
-    set(a.all()) != set(b.all()) before changing a configuration value to avoid
+    set(a) != set(b) before changing a configuration value to avoid
     (one-time) churn.
     """
 
     envs: tuple[ToxEnv, ...]
 
-    def all(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Generator[str, None, None]:
         for e in self.envs:
-            yield from e.all()
+            yield from iter(e)
 
     @classmethod
     def parse(cls, s: str) -> "ToxEnvlist":
@@ -52,11 +51,4 @@ class ToxEnvlist(ToxBase):
         return cls(tuple(pieces))
 
     def __str__(self) -> str:
-        buf = ""
-        default_suffix = "\n"
-
-        for item, last in _marklast(self.envs):
-            buf += str(item)
-            if not last:
-                buf += default_suffix
-        return buf
+        return "\n".join(str(x) for x in self.envs)

--- a/codemod_tox/options.py
+++ b/codemod_tox/options.py
@@ -6,7 +6,7 @@ from typing import Generator
 from .base import ToxBase
 
 
-@dataclass
+@dataclass(frozen=True)
 class ToxOptions(ToxBase):
     """
     A "generative" piece of a tox env name.
@@ -15,11 +15,15 @@ class ToxOptions(ToxBase):
     Whitespace is ignored when parsing, but always output without it.
 
     e.g. `{a , b }` -> `{a,b}`
+
+    Note that `options` should never be an empty tuple, even when parsing `{}`
+    it should be `("",)` -- one item, which is empty string.
     """
 
     options: tuple[str, ...]
 
-    def all(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Generator[str, None, None]:
+        assert self.options
         yield from self.options
 
     def removeprefix(self, prefix: str) -> "ToxOptions":

--- a/codemod_tox/utils.py
+++ b/codemod_tox/utils.py
@@ -5,13 +5,13 @@ from typing import Generator, Sequence, TypeVar
 T = TypeVar("T")
 
 
-def _marklast(seq: Sequence[T]) -> Generator[tuple[T, bool], None, None]:
+def marklast(seq: Sequence[T]) -> Generator[tuple[T, bool], None, None]:
     last_idx = len(seq) - 1
     for i, x in enumerate(seq):
         yield x, i == last_idx
 
 
-def _common_prefix(a: str, b: str) -> str:
+def common_prefix(a: str, b: str) -> str:
     buf = ""
     for c1, c2 in zip(a, b):
         if c1 != c2:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -4,13 +4,13 @@ from codemod_tox.env import HoistError, ToxEnv
 
 def test_env():
     e = ToxEnv.parse("py3{8,9,10}")
-    assert tuple(e.all()) == ("py38", "py39", "py310")
+    assert tuple(e) == ("py38", "py39", "py310")
     assert str(e) == "py3{8,9,10}"
 
 
 def test_multi_factor_env():
     e = ToxEnv.parse("{py27,py36}-django{15,16}")
-    assert tuple(e.all()) == (
+    assert tuple(e) == (
         "py27-django15",
         "py27-django16",
         "py36-django15",

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -3,24 +3,24 @@ from codemod_tox.envlist import ToxEnvlist
 
 def test_envlist():
     e = ToxEnvlist.parse("a , b{c,d},")
-    assert tuple(e.all()) == ("a", "bc", "bd")
+    assert tuple(e) == ("a", "bc", "bd")
 
 
 def test_trailing_comma():
     e = ToxEnvlist.parse("a,b")
-    assert tuple(e.all()) == ("a", "b")
+    assert tuple(e) == ("a", "b")
     e = ToxEnvlist.parse("a,b,")
-    assert tuple(e.all()) == ("a", "b")
+    assert tuple(e) == ("a", "b")
     assert str(e) == "a\nb"
 
     e = ToxEnvlist.parse("a , b , ")
-    assert tuple(e.all()) == ("a", "b")
+    assert tuple(e) == ("a", "b")
     assert str(e) == "a\nb"
 
     e = ToxEnvlist.parse("a\nb\n")
-    assert tuple(e.all()) == ("a", "b")
+    assert tuple(e) == ("a", "b")
     assert str(e) == "a\nb"
 
     e = ToxEnvlist.parse("a,b\nc")
-    assert tuple(e.all()) == ("a", "b", "c")
+    assert tuple(e) == ("a", "b", "c")
     assert str(e) == "a\nb\nc"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -10,7 +10,7 @@ def test_options_roundtrip():
 def test_options():
     o = ToxOptions.parse("{a,b,c}")
     assert o.options == ("a", "b", "c")
-    assert tuple(o.all()) == ("a", "b", "c")
+    assert tuple(o) == ("a", "b", "c")
     assert not o.startswith("a")
     assert o.common_prefix() == ""
 
@@ -24,5 +24,5 @@ def test_options2():
     assert str(o) == "{301,302}"
 
     o2 = o.removeprefix("3")
-    assert tuple(o2.all()) == ("01", "02")
+    assert tuple(o2) == ("01", "02")
     assert str(o2) == "{01,02}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from codemod_tox.utils import common_prefix, marklast
+
+
+def test_marklast():
+    assert list(marklast("abc")) == [("a", False), ("b", False), ("c", True)]
+
+
+def test_common_prefix():
+    assert common_prefix("", "") == ""
+    assert common_prefix("a", "") == ""
+    assert common_prefix("", "a") == ""
+    assert common_prefix("a", "a") == "a"
+    assert common_prefix("goal", "golf") == "go"


### PR DESCRIPTION
The API naming is inspired by ruby/rust, and the `map_all` somewhat after `filter_map`.

Uses the standard magic methods for `iter` and `bool` support, which give you the full strings each object would expand to.  The dataclass field is basically an implementation detail that callers shouldn't care about.

I'm pleasantly surprised that the `TypeVar` appears to work with a `lambda` in mypy.