### PR TITLE
changefirst [3/7] Add | and _bucket support, well-tested

### DIFF
--- a/codemod_tox/base.py
+++ b/codemod_tox/base.py
@@ -29,6 +29,27 @@ class ToxBase:
         """
         return self.map_all(lambda x: x.startswith(prefix))
 
+    def endswith(self, suffix: str) -> bool:
+        """
+        Returns whether all possibilities end with `suffix`.
+        """
+        return self.map_all(lambda x: x.endswith(suffix))
+
+    def only(self, value: str) -> bool:
+        """
+        Returns whether all possibilities are exactly `value`.
+        """
+        return self.map_all(value.__eq__)
+
+    def one(self) -> str:
+        """
+        Returns the string if only one string matches, otherwise raise ValueError.
+        """
+        s = set(self)
+        if len(s) == 1:
+            return next(iter(s))
+        raise ValueError(f"Multiple matches: {s}")
+
     def fold(self, func: Callable[[str, str], str]) -> str:
         """Like reduce"""
         prev = None

--- a/codemod_tox/env.py
+++ b/codemod_tox/env.py
@@ -143,6 +143,8 @@ class ToxEnv(ToxBase):
         """
         left, middle, right = self._bucket()
 
+        # When this loop exits, `i` is the number of prefix-match characters,
+        # up to `len(left)`.
         for i in range(len(value)):
             if i >= len(left):
                 break
@@ -151,13 +153,22 @@ class ToxEnv(ToxBase):
         else:
             i = len(value)
 
-        for j in range(len(value) - i):
+        # For single-literal envs, there is no middle, so scooch any
+        # non-prefix-matched piece over to the right before checking for suffix
+        # matches.
+        if not middle and not right:
+            left, right = left[:i], left[i:]
+        # When this loop exits, `j` is the number of suffix-match characters,
+        # up to `len(right)`.
+        for j in range(len(value)):
             if j >= len(right):
+                break
+            if i + j >= len(value):
                 break
             if value[-j - 1] != right[-j - 1]:
                 break
         else:
-            j = len(right)
+            j = len(value)
 
         # N.b. Have to be careful because j can be zero
         left, middle = left[:i], middle.addprefix(left[i:])

--- a/codemod_tox/options.py
+++ b/codemod_tox/options.py
@@ -26,9 +26,19 @@ class ToxOptions(ToxBase):
         assert self.options
         yield from self.options
 
+    def addprefix(self, prefix: str) -> "ToxOptions":
+        return self.__class__(tuple(prefix + x for x in self.options))
+
     def removeprefix(self, prefix: str) -> "ToxOptions":
         assert self.startswith(prefix)
         return self.__class__(tuple(x[len(prefix) :] for x in self.options))
+
+    def addsuffix(self, suffix: str) -> "ToxOptions":
+        return self.__class__(tuple(x + suffix for x in self.options))
+
+    def removesuffix(self, suffix: str) -> "ToxOptions":
+        assert self.endswith(suffix)
+        return self.__class__(tuple(x[: -len(suffix)] for x in self.options))
 
     @classmethod
     def parse(cls, s: str) -> "ToxOptions":

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -76,3 +76,9 @@ def test_or():
     # TODO requires trying with remaining left -> right if no right
     # This currently works but isn't minimal
     # assert str(ToxEnv.parse("acd") | "cd") == "{a,}cd"
+
+def test_one():
+    with pytest.raises(ValueError):
+        ToxEnv.parse("py{37,38}").one()
+    assert ToxEnv.parse("py{37}").one() == "py37"
+    assert ToxEnv.parse("py{37,37}").one() == "py37"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -73,9 +73,8 @@ def test_or():
     assert str(ToxEnv.parse("py37") | "py") == "py{37,}"
     assert str(ToxEnv.parse("{a,b}cd") | "cd") == "{a,b,}cd"
     assert str(ToxEnv.parse("{a,b}cd") | "xd") == "{ac,bc,x}d"
-    # TODO requires trying with remaining left -> right if no right
-    # This currently works but isn't minimal
-    # assert str(ToxEnv.parse("acd") | "cd") == "{a,}cd"
+    assert str(ToxEnv.parse("acd") | "cd") == "{a,}cd"
+
 
 def test_one():
     with pytest.raises(ValueError):


### PR DESCRIPTION
The majority of tox envs in the wild are quite simple, either literals (`style`) or literals followed by a generative (`py{37,38}`).  Having a common representation makes it easy to support most envs with little code, and a fallback can be added later if it proves necessary.