### PR TITLE
changefirst [4/7] Add the ability to modify an envlist

### DIFF
--- a/codemod_tox/exceptions.py
+++ b/codemod_tox/exceptions.py
@@ -4,3 +4,11 @@ class ParseError(SyntaxError):
 
 class HoistError(ValueError):
     pass
+
+
+class NoMatch(Exception):
+    pass
+
+
+class EmptyNow(Exception):
+    pass

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -1,4 +1,6 @@
+import pytest
 from codemod_tox.envlist import ToxEnvlist
+from codemod_tox.exceptions import NoMatch
 
 
 def test_envlist():
@@ -24,3 +26,30 @@ def test_trailing_comma():
     e = ToxEnvlist.parse("a,b\nc")
     assert tuple(e) == ("a", "b", "c")
     assert str(e) == "a\nb\nc"
+
+
+def test_changefirst():
+    e = ToxEnvlist.parse("py37, style")
+    result = e.changefirst(
+        (lambda x: x.startswith("py3")),
+        (lambda y: y | "py38"),
+    )
+    assert str(result) == "py3{7,8}\nstyle"
+    with pytest.raises(NoMatch):
+        e.changefirst(
+            (lambda x: x.startswith("foo")),
+            (lambda y: y | "py38"),
+        )
+
+    result = e.changefirst(
+        (lambda x: x.startswith("py3")),
+        (lambda y: None),
+    )
+    assert str(result) == "style"
+
+    e = ToxEnvlist.parse("py{37,38}")
+    result = e.changefirst(
+        (lambda x: True),
+        (lambda y: None),
+    )
+    assert str(result) == ""

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -28,28 +28,51 @@ def test_trailing_comma():
     assert str(e) == "a\nb\nc"
 
 
-def test_changefirst():
+def test_transform_matching():
     e = ToxEnvlist.parse("py37, style")
-    result = e.changefirst(
+    result = e.transform_matching(
         (lambda x: x.startswith("py3")),
         (lambda y: y | "py38"),
     )
     assert str(result) == "py3{7,8}\nstyle"
     with pytest.raises(NoMatch):
-        e.changefirst(
+        e.transform_matching(
             (lambda x: x.startswith("foo")),
             (lambda y: y | "py38"),
         )
 
-    result = e.changefirst(
+    result = e.transform_matching(
         (lambda x: x.startswith("py3")),
         (lambda y: None),
     )
     assert str(result) == "style"
 
     e = ToxEnvlist.parse("py{37,38}")
-    result = e.changefirst(
+    result = e.transform_matching(
         (lambda x: True),
         (lambda y: None),
     )
     assert str(result) == ""
+
+
+def test_transform_matching_max():
+    e = ToxEnvlist.parse("py37, tests, style, py38, py39")
+    result = e.transform_matching(
+        (lambda x: x.startswith("py3")),
+        (lambda y: y | "py310"),
+    )
+    assert str(result) == "py3{7,10}\ntests\nstyle\npy38\npy39"
+
+    result = e.transform_matching(
+        (lambda x: x.startswith("py3")),
+        (lambda y: y | "py310"),
+        max=2,
+    )
+    assert str(result) == "py3{7,10}\ntests\nstyle\npy3{8,10}\npy39"
+
+    result = e.transform_matching(
+        (lambda x: x.startswith("py3")),
+        (lambda y: y | "py310"),
+        max=None,
+    )
+    assert str(result) == "py3{7,10}\ntests\nstyle\npy3{8,10}\npy3{9,10}"


### PR DESCRIPTION
For the py-version-altering codemod, I could see this doing something like

```py
matcher = re.compile(r"py3[0-9]+").fullmatch
def replacer(e):
  return e | "py310"

newlist = envlist.changefirst(
  (lambda x: x.map_all(matcher)),
  replacer,
)
```

which is probably ergonomic enough, but looking for other ideas.