### PR TITLE
changefirst [5/7] Add support for conditional config

### DIFF
--- a/codemod_tox/__init__.py
+++ b/codemod_tox/__init__.py
@@ -1,3 +1,4 @@
+from .conditional import ToxConditional
 from .env import ToxEnv
 from .envlist import ToxEnvlist
 from .options import ToxOptions
@@ -7,4 +8,4 @@ try:
 except ImportError:  # pragma: no cover
     __version__ = "dev"
 
-__all__ = ["ToxEnv", "ToxEnvlist", "ToxOptions"]
+__all__ = ["ToxConditional", "ToxEnv", "ToxEnvlist", "ToxOptions"]

--- a/codemod_tox/conditional.py
+++ b/codemod_tox/conditional.py
@@ -26,7 +26,6 @@ class ToxConditional(ToxBase):
     def parse(cls, value: str) -> "ToxConditional":
         lines: list[tuple[Optional[ToxEnv], str]] = []
         for line in value.splitlines():
-            print(repr(line))
             match = TOX_CONDITIONAL_RE.fullmatch(line)
             if match:
                 lines.append(

--- a/codemod_tox/conditional.py
+++ b/codemod_tox/conditional.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ToxBase
+from .env import ToxEnv
+from .parse import TOX_CONDITIONAL_RE
+
+
+@dataclass(frozen=True)
+class ToxConditional(ToxBase):
+    lines: tuple[tuple[Optional[ToxEnv], str], ...]
+
+    def evaluate(self, env: str) -> str:
+        buf: list[str] = []
+        for i, j in self.lines:
+            if isinstance(i, ToxEnv):
+                if i.matches(env):
+                    buf.append(j)
+            else:
+                buf.append(j)
+        return "\n".join(buf)
+
+    @classmethod
+    def parse(cls, value: str) -> "ToxConditional":
+        lines: list[tuple[Optional[ToxEnv], str]] = []
+        for line in value.splitlines():
+            print(repr(line))
+            match = TOX_CONDITIONAL_RE.fullmatch(line)
+            if match:
+                lines.append(
+                    (ToxEnv.parse(match.group("condition")), match.group("line"))
+                )
+            else:
+                lines.append((None, line))
+
+        return cls(tuple(lines))
+
+    def __str__(self) -> str:
+        return "\n".join(
+            "%s: %s" % (i, j) if i is not None else j for i, j in self.lines
+        )

--- a/codemod_tox/env.py
+++ b/codemod_tox/env.py
@@ -43,6 +43,12 @@ class ToxEnv(ToxBase):
                 r = dict(zip(option_locations, p))
                 yield "".join([r.get(i, x) for i, x in enumerate(self.pieces)])
 
+    def matches(self, other: str) -> bool:
+        factors = set(other.split("-"))
+        return self.map_any(other.__eq__) or self.map_any(
+            lambda x: bool(factors & set(x.split("-")))
+        )
+
     def common_factors(self) -> set[str]:
         """
         Returns the set of factors contained in all envs

--- a/codemod_tox/parse.py
+++ b/codemod_tox/parse.py
@@ -1,6 +1,9 @@
 import re
 
 TOX_ENV_TOKEN_RE = re.compile(
-    r"(?P<comma>,[ \t]*)|(?P<newline>\n)|(?P<space>[ \t]+)|(?P<literal>[A-Za-z0-9-_]+)|(?P<options>\{[^{}\s]+\})"
+    r"(?P<comma>,[ \t]*)|(?P<newline>\n)|(?P<space>[ \t]+)|(?P<literal>[A-Za-z0-9_-]+)|(?P<options>\{[^{}]+\})"
+)
+TOX_CONDITIONAL_RE = re.compile(
+    r"\s*(?P<condition>(?:,|[A-Za-z0-9_-]+|\{[^{}]+\})+)\s*:\s*(?P<line>.*)"
 )
 PY_FACTOR_RE = re.compile(r"^py(3\d+)")

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -1,0 +1,27 @@
+from codemod_tox.conditional import ToxConditional
+from codemod_tox.env import ToxEnv
+from codemod_tox.options import ToxOptions
+
+
+def test_conditional():
+    c = ToxConditional.parse("x\ny: z")
+    assert c.lines == (
+        (None, "x"),
+        (ToxEnv(("y",)), "z"),
+    )
+    assert str(c) == "x\ny: z"
+    assert c.evaluate("foo") == "x"
+    assert c.evaluate("yy") == "x"
+    assert c.evaluate("y") == "x\nz"
+    assert c.evaluate("foo-y") == "x\nz"
+
+
+def test_conditional_expands():
+    c = ToxConditional.parse("{lint, tests}: x")
+    assert str(c) == "{lint,tests}: x"
+    assert c.lines == (
+        # (force line break)
+        (ToxEnv((ToxOptions(("lint", "tests")),)), "x"),
+    )
+    assert c.evaluate("foo") == ""
+    assert c.evaluate("foo-tests") == "x"

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -2,18 +2,25 @@ from codemod_tox.conditional import ToxConditional
 from codemod_tox.env import ToxEnv
 from codemod_tox.options import ToxOptions
 
+DEPS_EXAMPLE = """\
+-rrequirements.txt
+flask: flask>0
+fastapi: fastapi>0"""
+
 
 def test_conditional():
-    c = ToxConditional.parse("x\ny: z")
+    c = ToxConditional.parse(DEPS_EXAMPLE)
     assert c.lines == (
-        (None, "x"),
-        (ToxEnv(("y",)), "z"),
+        (None, "-rrequirements.txt"),
+        (ToxEnv(("flask",)), "flask>0"),
+        (ToxEnv(("fastapi",)), "fastapi>0"),
     )
-    assert str(c) == "x\ny: z"
-    assert c.evaluate("foo") == "x"
-    assert c.evaluate("yy") == "x"
-    assert c.evaluate("y") == "x\nz"
-    assert c.evaluate("foo-y") == "x\nz"
+    assert str(c) == DEPS_EXAMPLE
+    assert c.evaluate("py38") == "-rrequirements.txt"
+    # Don't accidentally substring match, only full factors
+    assert c.evaluate("py38-zflask-zfastapi") == "-rrequirements.txt"
+    assert c.evaluate("py38-flask") == "-rrequirements.txt\nflask>0"
+    assert c.evaluate("py38-flask-fastapi") == "-rrequirements.txt\nflask>0\nfastapi>0"
 
 
 def test_conditional_expands():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[tox]
+envlist = foo-{bar, baz}

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,0 @@
-[tox]
-envlist = foo-{bar, baz}


### PR DESCRIPTION
This is allowed several places in the tox config, for example env vars, dependencies, or commands.  You can list either a generative expression (that we call `ToxEnv`) or just a factor (a dash-separated piece).  I don't think you can include multiple factors without it being a full env expression.

Use case: When editing a certain `ToxEnv` in `envlist` you might want to find references to that same `ToxEnv` to replace it as well.  (You can use `.changefirst` on the `envlist` if your replacer callback saves both old and new, I suppose.)

I'm not 100% sure this is parsing things correctly, but seems to work on ~all of the files I have in front of me.