### PR TITLE
fix: don't add numeric factors if there isn't already an option.

### DIFF
--- a/codemod_tox/envlist.py
+++ b/codemod_tox/envlist.py
@@ -6,6 +6,7 @@ from typing import Callable, Generator, Optional
 from .base import ToxBase
 from .env import ToxEnv
 from .exceptions import NoFactorMatch, NoMatch
+from .options import ToxOptions
 from .parse import TOX_ENV_TOKEN_RE
 
 
@@ -86,6 +87,9 @@ class ToxEnvlist(ToxBase):
         new_envs: list[ToxEnv] = []
         added = False
         for env in self.envs:
+            if not any(isinstance(p, ToxOptions) for p in env.pieces):
+                new_envs.append(env)
+                continue
             try:
                 new_envs.append(env.add_numeric_option(value))
                 added = True

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -106,3 +106,11 @@ def test_add_numeric_option_to_envlist():
     e = ToxEnvlist.parse("py3{9,10}-django{5,6}-cov{6,7}, py3{9,10}-nocov, style")
     result = e.add_numeric_option("py311")
     assert str(result) == "py3{9,10,11}-django{5,6}-cov{6,7}\npy3{9,10,11}-nocov\nstyle"
+
+    e = ToxEnvlist.parse("py37,py310,linters")
+    result = e.add_numeric_option("py313")
+    assert str(result) == "py37\npy310\nlinters\npy313"
+
+    e = ToxEnvlist.parse("py3{6,10},py37,linters")
+    result = e.add_numeric_option("py313")
+    assert str(result) == "py3{6,10,13}\npy37\nlinters"


### PR DESCRIPTION
Encountered in the wild: these incorrect additions when adding py313:

```diff
-envlist = py37,py310,linters
+envlist = py{37,313}
+  py{310,313}
+  linters
```

and:

```diff
-envlist = py3{6,10}
-  py37
+envlist = py3{6,10,13}
+  py{37,313}
```